### PR TITLE
added Hazelcast Enterprise repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,4 +18,15 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+    <!-- https://github.com/hazelcast/hazelcast/blob/master/hazelcast-documentation/src/InstallingHZEnterprise.md -->
+    <repositories>
+        <repository>
+            <id>Hazelcast Private Snapshot Repository</id>
+            <url>https://repository-hazelcast-l337.forge.cloudbees.com/snapshot/</url>
+        </repository>
+        <repository>
+            <id>Hazelcast Private Release Repository</id>
+            <url>https://repository-hazelcast-l337.forge.cloudbees.com/release/</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Hi @dbrimley 

Hazelcast Enterprise maven repository was missing from `pom.xml`.

Doc http://docs.hazelcast.org/docs/latest/manual/html/installinghzenterprise.html 
